### PR TITLE
Updated syllabus:  data-stories-reich-syllabus.tex

### DIFF
--- a/assets/syllabus/data-stories-reich-syllabus.tex
+++ b/assets/syllabus/data-stories-reich-syllabus.tex
@@ -230,8 +230,7 @@ F & 0-59 \\
 \item Describe the basic concepts of probability, random variation and selected, commonly used, probability distributions.
 \item Select and perform the appropriate descriptive and inferential statistical methods in selected basic study design settings.
 \item Describe appropriate methodological alternatives to commonly used statistical methods when assumptions are violated.
-\item Integrate analysis strategies in biostatistics with principles and issues in epidemiology.
-literature
+\item Integrate analysis strategies in biostatistics with principles and issues in epidemiology iterature.
 \item Develop written and oral presentations based on statistical analyses for both public health professionals and educated lay audiences.
 \item Apply statistical methods to solve problems in the health sciences and carry out theoretical research in statistical methodology.
 \end{itemize}


### PR DESCRIPTION
Reposition a period under "Council of Education for Public Health (CEPH) Course Competencies" heading. Bullet point 9 read: "....epidemiology. literature." I changed to read: "...epidemiology literature."